### PR TITLE
Merge from gui-drives dev branch

### DIFF
--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -76,7 +76,6 @@ class Spacecraft:
     def set_tonnage(self, new_tonnage):
         """
         Sets the tonnage of an existing Spacecraft
-
         :param new_tonnage: The tonnage to update to
         """
         tonnage_cost_data = get_file_data("hull_data.json")
@@ -95,7 +94,6 @@ class Spacecraft:
     def set_fuel(self, new_fuel):
         """
         Sets the max fuel of an existing Spacecraft
-
         :param new_fuel: The fuel to update to
         """
         self.cargo = self.cargo - new_fuel
@@ -104,50 +102,65 @@ class Spacecraft:
     def add_jdrive(self, drive_type):
         """
         Adds a jump drive to the spaceship
-
         :param drive_type: The drive designation letter
         """
         # create new jdrive object
         new_jdrive = JDrive(drive_type)
 
-        # if drive already in place, replace stats
-        if self.jdrive is not None:
-            self.cost_total = self.cost_total - self.jdrive.cost
-            self.cargo = self.cargo + self.jdrive.tonnage
+        # Error checking to see if new drive type is incompatible
+        if self.performance_by_volume("jdrive", drive_type) is not None:
+            # if drive already in place, replace stats
+            if self.jdrive is not None:
+                self.cost_total = self.cost_total - self.jdrive.cost
+                self.cargo = self.cargo + self.jdrive.tonnage
 
-        # assign object to ship, update cost & tonnage
-        self.jdrive = new_jdrive
-        self.cost_total = self.cost_total + new_jdrive.cost
-        self.cargo = self.cargo - new_jdrive.tonnage
-        self.performance_by_volume("jdrive", drive_type)
+            # assign object to ship, update cost & tonnage
+            self.jdrive = new_jdrive
+            self.cost_total = self.cost_total + new_jdrive.cost
+            self.cargo = self.cargo - new_jdrive.tonnage
+        
 
     def add_mdrive(self, drive_type):
         """
         Adds a maneuver drive to the spaceship
-
         :param drive_type: The drive designation letter
         """
         # create new mdrive object
         new_mdrive = MDrive(drive_type)
 
-        # if drive already in place, replace stats
-        if self.mdrive is not None:
-            self.cost_total = self.cost_total - self.mdrive.cost
-            self.cargo = self.cargo + self.mdrive.tonnage
+        # Error checking to see if new drive type is incompatible
+        if self.performance_by_volume("mdrive", drive_type) is not None:
+            # if drive already in place, replace stats
+            if self.mdrive is not None:
+                self.cost_total = self.cost_total - self.mdrive.cost
+                self.cargo = self.cargo + self.mdrive.tonnage
 
-        # assign object to ship, update cost & tonnage
-        self.mdrive = new_mdrive
-        self.cost_total = self.cost_total + new_mdrive.cost
-        self.cargo = self.cargo - new_mdrive.tonnage
-        self.performance_by_volume("mdrive", drive_type)
+            # assign object to ship, update cost & tonnage
+            self.mdrive = new_mdrive
+            self.cost_total = self.cost_total + new_mdrive.cost
+            self.cargo = self.cargo - new_mdrive.tonnage
+        
 
     def performance_by_volume(self, drive, drive_letter):
+        """
+        Handles checking whether a drive type is compatible and retrieves the relative jump/thrust numbers
+        for a drive type
+        :param drive: drive type
+        :param drive_letter: letter of the drive 
+        :return: None if incompatible
+        """
         data = get_file_data("hull_performance.json")
         index = get_file_data("hull_performance_index.json")
         performance_list = data.get(drive_letter).get("jumps_per_hull_volume")
 
         # Get the nearest ton rounded down
         index = index.get(str(self.tonnage))
+
+        # Error checking to see if drive type is incompatible with the hull size
+        if index >= len(performance_list):
+            print("Error: non-compatible drive to tonnage value - Drive {} to {}".format(drive_letter, self.tonnage))
+            return None
+
         value = performance_list[int(index)]
 
         # Error checking if the drive type is non-compatible with the hull size
@@ -160,10 +173,11 @@ class Spacecraft:
         if drive == "jdrive":
             self.jump = value
 
+        return 1
+
     def add_pplant(self, plant_type):
         """
         Adds a power plant to the spaceship
-
         :param plant_type: The plant designation letter
         """
         # create new pplant object

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -87,9 +87,14 @@ class Spacecraft:
             if current.get('tonnage') == int(new_tonnage):
                 new_cost = current.get("cost")
 
+        # update cargo, tonnage, cost
         self.cargo = self.cargo + (new_tonnage - self.tonnage)
         self.tonnage = new_tonnage
         self.cost_total += new_cost
+
+        # set hp based on tonnage
+        self.hull_hp = self.tonnage // 50
+        self.structure_hp = self.tonnage // 50
 
     def set_fuel(self, new_fuel):
         """

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -79,8 +79,18 @@ class Spacecraft:
 
         :param new_tonnage: The tonnage to update to
         """
+        tonnage_cost_data = get_file_data("hull_data.json")
+        new_cost = 0
+        for key in tonnage_cost_data:
+            current = tonnage_cost_data.get(key)
+            if current.get('tonnage') == self.tonnage:
+                self.cost_total -= current.get("cost")
+            if current.get('tonnage') == int(new_tonnage):
+                new_cost = current.get("cost")
+
         self.cargo = self.cargo + (new_tonnage - self.tonnage)
         self.tonnage = new_tonnage
+        self.cost_total += new_cost
 
     def set_fuel(self, new_fuel):
         """
@@ -142,7 +152,7 @@ class Spacecraft:
 
         # Error checking if the drive type is non-compatible with the hull size
         if value == 0:
-            print("Error: non-compatible drive to tonnage value - {} to {}".format(drive, self.tonnage))
+            print("Error: non-compatible drive to tonnage value - Drive {} to {}".format(drive_letter, self.tonnage))
             return None
 
         if drive == "mdrive":

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -78,10 +78,6 @@ class Spacecraft:
         Sets the tonnage of an existing Spacecraft
         :param new_tonnage: The tonnage to update to
         """
-        if new_tonnage > 2000:
-            print("Error: Tonnage exceeds maximum ship limit. {} > 2000".format(new_tonnage))
-            return
-
         tonnage_cost_data = get_file_data("hull_data.json")
         new_cost = 0
         for item in tonnage_cost_data.values():
@@ -126,7 +122,6 @@ class Spacecraft:
             self.jdrive = new_jdrive
             self.cost_total = self.cost_total + new_jdrive.cost
             self.cargo = self.cargo - new_jdrive.tonnage
-        
 
     def add_mdrive(self, drive_type):
         """
@@ -148,7 +143,6 @@ class Spacecraft:
             self.cost_total = self.cost_total + new_mdrive.cost
             self.cargo = self.cargo - new_mdrive.tonnage
         
-
     def performance_by_volume(self, drive, drive_letter):
         """
         Handles checking whether a drive type is compatible and retrieves the relative jump/thrust numbers

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -138,7 +138,7 @@ class Spacecraft:
 
         # Get the nearest ton rounded down
         index = index.get(str(self.tonnage))
-        value = performance_list[index]
+        value = performance_list[int(index)]
 
         # Error checking if the drive type is non-compatible with the hull size
         if value == 0:

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -78,14 +78,17 @@ class Spacecraft:
         Sets the tonnage of an existing Spacecraft
         :param new_tonnage: The tonnage to update to
         """
+        if new_tonnage > 2000:
+            print("Error: Tonnage exceeds maximum ship limit. {} > 2000".format(new_tonnage))
+            return
+
         tonnage_cost_data = get_file_data("hull_data.json")
         new_cost = 0
-        for key in tonnage_cost_data:
-            current = tonnage_cost_data.get(key)
-            if current.get('tonnage') == self.tonnage:
-                self.cost_total -= current.get("cost")
-            if current.get('tonnage') == int(new_tonnage):
-                new_cost = current.get("cost")
+        for item in tonnage_cost_data.values():
+            if item.get('tonnage') == self.tonnage:
+                self.cost_total -= item.get("cost")
+            if item.get('tonnage') == int(new_tonnage):
+                new_cost = item.get("cost")
 
         # update cargo, tonnage, cost
         self.cargo = self.cargo + (new_tonnage - self.tonnage)

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -73,10 +73,10 @@ class Window(QWidget):
         self.thrust_line_edit = add_stat_to_layout("Thrust:", 4, signal_function=self.edit_mdrive)
 
         # Hull HP
-        self.hull_hp_line_edit = add_stat_to_layout("Hull HP:", 5, read_only=True)
+        self.hull_hp_line_edit = add_stat_to_layout("Hull HP:", 5, signal_function=self.edit_tonnage, read_only=True)
 
         # Structure HP
-        self.structure_hp_line_edit = add_stat_to_layout("Structure HP:", 6, read_only=True)
+        self.structure_hp_line_edit = add_stat_to_layout("Structure HP:", 6, signal_function=self.edit_tonnage, read_only=True)
 
         # Armor
         self.armour_line_edit = add_stat_to_layout("Armour:", 7, read_only=True)

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -59,6 +59,7 @@ class Window(QWidget):
 
         # Tonnage
         self.tonnage_line_edit = add_stat_to_layout("Tonnage:", 0, signal_function=self.edit_tonnage, force_int=True)
+        self.tonnage_line_edit.validator().setBottom(0)
 
         # Cargo
         self.cargo_line_edit = add_stat_to_layout("Cargo:", 1, read_only=True)
@@ -145,6 +146,7 @@ class Window(QWidget):
             self.spacecraft.add_mdrive(drive_type)
         else:
             print("Error: Incompatible drive type. Drive types are A-Z")
+
 
 if __name__ == '__main__':
     import sys

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -63,14 +63,14 @@ class Window(QWidget):
         # Cargo
         self.cargo_line_edit = add_stat_to_layout("Cargo:", 1, read_only=True)
 
-        # Fuel
+        # Fuels
         self.fuel_line_edit = add_stat_to_layout("Fuel:", 2, signal_function=self.edit_fuel, force_int=True)
 
         # Jump
         self.jump_line_edit = add_stat_to_layout("Jump:", 3, signal_function=self.edit_jdrive)
 
         # Thrust
-        self.thrust_line_edit = add_stat_to_layout("Thrust:", 4, read_only=True)
+        self.thrust_line_edit = add_stat_to_layout("Thrust:", 4, signal_function=self.edit_mdrive)
 
         # Hull HP
         self.hull_hp_line_edit = add_stat_to_layout("Hull HP:", 5, read_only=True)
@@ -133,7 +133,18 @@ class Window(QWidget):
         drive_type = self.jump_line_edit.text()
         if drive_type.isalpha():
             self.spacecraft.add_jdrive(drive_type)
+        else:
+            print("Error: Incompatible drive type. Drive types are A-Z")
 
+    def edit_mdrive(self):
+        """
+        Update the spacecraft thrust drive
+        """
+        drive_type = self.thrust_line_edit.text()
+        if drive_type.isalpha():
+            self.spacecraft.add_mdrive(drive_type)
+        else:
+            print("Error: Incompatible drive type. Drive types are A-Z")
 
 if __name__ == '__main__':
     import sys

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -131,7 +131,7 @@ class Window(QWidget):
         Update the spacecraft jump drive
         """
         drive_type = self.jump_line_edit.text()
-        if drive_type.isalpha():
+        if drive_type.isalpha() and len(drive_type) == 1:
             self.spacecraft.add_jdrive(drive_type)
         else:
             print("Error: Incompatible drive type. Drive types are A-Z")
@@ -141,7 +141,7 @@ class Window(QWidget):
         Update the spacecraft thrust drive
         """
         drive_type = self.thrust_line_edit.text()
-        if drive_type.isalpha():
+        if drive_type.isalpha() and len(drive_type) == 1:
             self.spacecraft.add_mdrive(drive_type)
         else:
             print("Error: Incompatible drive type. Drive types are A-Z")

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -3,8 +3,8 @@ shipyard.py
 
 Entrypoint for the imperium-shipyard program (https://github.com/Milkshak3s/imperium-shipyard)
 """
-import data_generators as dg
-from models.spacecraft import Spacecraft
+import imperium.data_generators as dg
+from imperium.models.spacecraft import Spacecraft
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QDoubleValidator, QIntValidator
 from PyQt5.QtWidgets import (QApplication, QComboBox, QGridLayout, QGroupBox,
@@ -42,7 +42,7 @@ class Window(QWidget):
             new_label = QLabel(label)
             new_line_edit = QLineEdit()
             new_line_edit.setFixedWidth(50)
-            new_line_edit.setValidator(QIntValidator(new_line_edit))
+            # new_line_edit.setValidator(QIntValidator(new_line_edit))
 
             if signal_function is not None:
                 new_line_edit.editingFinished.connect(signal_function)
@@ -67,7 +67,7 @@ class Window(QWidget):
         self.fuel_line_edit = add_stat_to_layout("Fuel:", 2, signal_function=self.edit_fuel, force_int=True)
 
         # Jump
-        self.jump_line_edit = add_stat_to_layout("Jump:", 3, read_only=True)
+        self.jump_line_edit = add_stat_to_layout("Jump:", 3, signal_function=self.edit_jdrive)
 
         # Thrust
         self.thrust_line_edit = add_stat_to_layout("Thrust:", 4, read_only=True)
@@ -125,6 +125,14 @@ class Window(QWidget):
         """
         new_fuel = int(self.fuel_line_edit.text())
         self.spacecraft.set_fuel(new_fuel)
+
+    def edit_jdrive(self):
+        """
+        Update the spacecraft jump drive
+        """
+        drive_type = self.jump_line_edit.text()
+        if drive_type.isalpha():
+            self.spacecraft.add_jdrive(drive_type)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added functionality and correct logic parsing for the GUI elements of the j- and m- drives.

Refactored some documentation in spacecraft.py for uniformity.

Updated spacecraft::set_tonnage to properly alter cargo and cost when switching the tonnage. May need more testing, but related objects seems to be adjusting correctly.

Note: at the moment, all error messages are printed out to the terminal window. Direction could be a small box within the GUI that handles these stdout statements.