### PR TITLE
Merge from gui-hardpoints development branch

### DIFF
--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -1,0 +1,17 @@
+"""
+@file hardpoint.py
+
+Represents a single hardpoint on a ship and its contained items/customizations
+"""
+class Hardpoint:
+    def __init__(self):
+        self.turret      = None     # turret object
+
+    def add_turret(self, turret):
+        self.turret = turret
+
+    def get_cost(self):
+        return self.turret.cost
+
+    def get_tonnage(self):
+        return self.turret.tonnage

--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -4,7 +4,8 @@
 Represents a single hardpoint on a ship and its contained items/customizations
 """
 class Hardpoint:
-    def __init__(self):
+    def __init__(self, id):
+        self.id          = id       # hardpoint id
         self.turret      = None     # turret object
 
     def add_turret(self, turret):

--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -49,7 +49,7 @@ class Hardpoint:
         Handles getting the total tonnage of a hardpoint and its options
         :return: tonnage
         """
-        tonnage = 0
+        tonnage = 1
 
         if self.turret is not None:
             tonnage += self.turret.tonnage

--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -3,16 +3,48 @@
 
 Represents a single hardpoint on a ship and its contained items/customizations
 """
+from imperium.models.json_reader import get_file_data
+
+
 class Hardpoint:
     def __init__(self, id):
+        self.data = get_file_data("hull_turrets.json")
         self.id          = id       # hardpoint id
         self.turret      = None     # turret object
+        self.popup       = False
+        self.fixed       = False
+
+    def modify_addon(self, part):
+        """
+        Handles adding an add-on to the turret
+        :param part: Name of the add-on to add
+        """
+        if part == "Pop-up Turret":
+            self.popup ^= True
+        if part == "Fixed Mounting":
+            self.fixed ^= True
 
     def add_turret(self, turret):
         self.turret = turret
 
     def get_cost(self):
-        return self.turret.cost
+        cost = 0
+
+        if self.turret is not None:
+            cost += self.turret.get_cost()
+        if self.popup is True:
+            cost += 1.0
+        if self.fixed is True:
+            cost *= 0.5
+
+        return cost
 
     def get_tonnage(self):
-        return self.turret.tonnage
+        tonnage = 0
+
+        if self.turret is not None:
+            tonnage += self.turret.tonnage
+        if self.popup is True:
+            tonnage += 2.0
+
+        return tonnage

--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -25,9 +25,14 @@ class Hardpoint:
             self.fixed ^= True
 
     def add_turret(self, turret):
+        # Modifying/adding turret of a hardpoint
         self.turret = turret
 
     def get_cost(self):
+        """
+        Handles getting the total cost of a hardpoint and its options
+        :return: cost
+        """
         cost = 0
 
         if self.turret is not None:
@@ -40,6 +45,10 @@ class Hardpoint:
         return cost
 
     def get_tonnage(self):
+        """
+        Handles getting the total tonnage of a hardpoint and its options
+        :return: tonnage
+        """
         tonnage = 0
 
         if self.turret is not None:

--- a/imperium/models/hardpoint.py
+++ b/imperium/models/hardpoint.py
@@ -52,7 +52,7 @@ class Hardpoint:
         tonnage = 1
 
         if self.turret is not None:
-            tonnage += self.turret.tonnage
+            tonnage += self.turret.get_tonnage()
         if self.popup is True:
             tonnage += 2.0
 

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -23,6 +23,8 @@ class Spacecraft:
         self.fuel_jump          = 0 # amount of fuel required for a jump
         self.fuel_two_weeks     = 0 # amount of fuel required for 2 weeks of operation
         self.armour_total       = 0 # total armour pointage
+        self.num_hardpoints     = 0 # total number of hardpoints
+        self.hardpoints         = list() # list of added hardpoints
         self.hull_designation   = None   # A, B, C, etc.
         self.hull_type          = None   # steamlined, distributed, standard, etc.
         self.hull_options       = list() # list of hull options installed
@@ -49,6 +51,7 @@ class Spacecraft:
         # set hp based on tonnage
         self.hull_hp = self.tonnage // 50
         self.structure_hp = self.tonnage // 50
+        self.num_hardpoints = self.tonnage // 100
 
         # pull hull cost from json, set that
         data = get_file_data("hull_data.json")
@@ -181,6 +184,7 @@ class Spacecraft:
         # set hp based on tonnage
         self.hull_hp = self.tonnage // 50
         self.structure_hp = self.tonnage // 50
+        self.num_hardpoints = self.tonnage // 100
 
     def set_fuel(self, new_fuel):
         """

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -298,24 +298,6 @@ class Spacecraft:
                     return "Error: PPlant under M-Drive. {} < {}".format(self.pplant.type, self.mdrive.drive_type)
         return True
 
-    def add_turret(self, turret):
-        """
-        Adds a single turret to the spaceship
-        :param turret: Turret object to append
-        """
-        self.turrets.append(turret)
-
-    def remove_turret(self, turret_index):
-        """
-        Removes a single turret from the spaceship
-        :param turret_index: Index of the turret to remove
-        """
-        if len(self.turrets) != (turret_index + 1):
-            return
-
-        turret = self.turrets[turret_index]
-        self.turrets.remove(turret)
-
     def get_bridge_tonnage(self):
         """
         Handles calculating the cost of a main component bridge to the ship based on the hull size

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -465,3 +465,13 @@ class Spacecraft:
     def modify_fuel_scoops(self):
         # Toggles fuel scoops state
         self.fuel_scoop ^= True
+
+    def add_hardpoint(self, hp):
+        # Adds a hardpoint to the ship
+        self.hardpoints.append(hp)
+
+    def remove_hardpoint(self, hp):
+        # Removes a hardpoint from ship, if exists
+        for h in self.hardpoints:
+            if h == hp:
+                self.hardpoints.remove(h)

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -35,7 +35,6 @@ class Spacecraft:
         self.pplant             = None   # pplant object
         self.armour             = list() # list of armour objects
         self.sensors            = None   # sensor object
-        self.turrets            = list() # list of turret objects
         self.bays               = list() # list of bay objects
         self.screens            = list() # list of screen objects
         self.computer           = None   # computer object

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -473,5 +473,5 @@ class Spacecraft:
     def remove_hardpoint(self, hp):
         # Removes a hardpoint from ship, if exists
         for h in self.hardpoints:
-            if h == hp:
+            if h is hp:
                 self.hardpoints.remove(h)

--- a/imperium/models/spacecraft.py
+++ b/imperium/models/spacecraft.py
@@ -106,10 +106,8 @@ class Spacecraft:
             cost_total += self.sensors.cost
 
         # Turrets / Bayweapons
-        for turret in self.turrets:
-            cost_total += turret.cost
-        for bayweapon in self.bays:
-            cost_total += bayweapon.cost
+        for hardpoint in self.hardpoints:
+            cost_total += hardpoint.get_cost()
 
         # Screens / Computer / Software
         for screen in self.screens:
@@ -155,10 +153,8 @@ class Spacecraft:
             cargo -= self.sensors.tonnage
 
         # Turrets / Bayweapons / Screens
-        for turret in self.turrets:
-            cargo -= turret.tonnage
-        for bayweapon in self.bays:
-            cargo -= bayweapon.tonnage
+        for hardpoint in self.hardpoints:
+            cargo -= hardpoint.get_tonnage()
         for screen in self.screens:
             cargo -= screen.tonnage
 

--- a/imperium/models/turrets.py
+++ b/imperium/models/turrets.py
@@ -23,13 +23,45 @@ class Turret:
         self.weapons         = [None for _ in range(self.max_wep)] # list of the weapons on this turret
         self.cost            = self.model.get("cost")              # cost of the turret and addons
 
+        # Setting up missile dictionary for display
+        self.missiles        = dict()
+        for mtype in data.get("weapons").get("Missile Rack").get("types").keys():
+            self.missiles[mtype] = 0
+
+        self.sandcaster_barrels = 0                                # number of sandcaster barrels on turret
+
     def get_cost(self):
         cost = 0
         cost += self.cost
+
+        # Adding weapon cost
         for wep in self.weapons:
             if wep is not None:
                 cost += wep.get("cost")
+
+        # Adding missile costs
+        missile_costs = self.data.get("weapons").get("Missile Rack").get("types")
+        for key in self.missiles.keys():
+            cost += self.missiles.get(key) * missile_costs.get(key)
+
+        # Adding sandcaster costs
+        sand_data = self.data.get("weapons").get("Sandcaster").get("barrel_cost")
+        cost += self.sandcaster_barrels * sand_data
+
         return cost
+
+    def get_tonnage(self):
+        tonnage = 0
+        tonnage += self.tonnage
+
+        # Get missile tonnages
+        for key in self.missiles.keys():
+            tonnage += self.missiles.get(key)
+
+        # Get sandcaster tonnages
+        tonnage += self.sandcaster_barrels
+
+        return tonnage
 
     def modify_weapon(self, part, idx):
         if part == "---":
@@ -37,3 +69,10 @@ class Turret:
         else:
             wep = self.data.get("weapons").get(part)
         self.weapons[idx] = wep
+
+    def modify_missile_ammo(self, type, num):
+        if type in self.missiles.keys():
+            self.missiles[type] = num
+
+    def modify_sandcaster_barrel(self, num):
+        self.sandcaster_barrels = num

--- a/imperium/models/turrets.py
+++ b/imperium/models/turrets.py
@@ -20,46 +20,20 @@ class Turret:
         self.model           = data.get("models").get(model_type)  # model of the turret
         self.tonnage         = self.model.get("tonnage")           # size of the turret and addons
         self.max_wep         = self.model.get("num_weapons")       # max number of weapons per turret type
-        self.weapons         = list()                              # list of the weapons on this turret
+        self.weapons         = [None for _ in range(self.max_wep)] # list of the weapons on this turret
         self.cost            = self.model.get("cost")              # cost of the turret and addons
 
     def get_cost(self):
         cost = 0
         cost += self.cost
         for wep in self.weapons:
-            cost += wep.cost
+            if wep is not None:
+                cost += wep.get("cost")
         return cost
 
-    def add_weapon(self, part):
-        """
-        Handles adding weapons to the turret
-        :param part: Name of the weapon to add
-        """
-        if len(self.weapons) == self.max_wep:
-            print("Error: cannot add '{}'. Max # of weapons reached for {}: {}/{}".format(
-                part, self.name, len(self.weapons), self.max_wep))
-            return
-
-        weapon = self.data.get("weapons").get(part)
-
-        self.weapons.append(weapon)
-        self.cost += weapon.get("cost")
-
-    def remove_weapon(self, part):
-        """
-        Handles removing a specific weapon from the turret
-        :param part: Name of the weapon to remove
-        """
-        if len(self.weapons) == 0:
-            print("Error: no weapons to remove.")
-            return
-
-        wep = self.data.get("weapons").get(part)
-
-        # Check if any weapon matches this weapon. If none, print error.
-        for w in self.weapons:
-            if wep == w:
-                self.weapons.remove(w)
-                self.cost -= w.get("cost")
-                return
-        print("Error: {} not attached to {}".format(part, self.name))
+    def modify_weapon(self, part, idx):
+        if part == "---":
+            wep = None
+        else:
+            wep = self.data.get("weapons").get(part)
+        self.weapons[idx] = wep

--- a/imperium/models/turrets.py
+++ b/imperium/models/turrets.py
@@ -25,9 +25,10 @@ class Turret:
 
     def get_cost(self):
         cost = 0
-        cost += self.tonnage
+        cost += self.cost
         for wep in self.weapons:
             cost += wep.cost
+        return cost
 
     def add_weapon(self, part):
         """

--- a/imperium/models/turrets.py
+++ b/imperium/models/turrets.py
@@ -19,26 +19,15 @@ class Turret:
         self.name            = model_type                          # name of the model
         self.model           = data.get("models").get(model_type)  # model of the turret
         self.tonnage         = self.model.get("tonnage")           # size of the turret and addons
-        self.addons          = list()                              # list of the addons for this turret
         self.max_wep         = self.model.get("num_weapons")       # max number of weapons per turret type
         self.weapons         = list()                              # list of the weapons on this turret
         self.cost            = self.model.get("cost")              # cost of the turret and addons
 
-    def add_addon(self, part):
-        """
-        Handles adding an add-on to the turret
-        :param part: Name of the add-on to add
-        """
-        addon = self.data.get("addons").get(part)
-
-        # Appending addon and related costs to turret fields
-        self.addons.append(addon)
-        self.tonnage += addon.get("tonnage")
-
-        if part == "Pop-up Turret":
-            self.cost += addon.get("cost")
-        if part == "Fixed Mounting":
-            self.cost *= addon.get("turret_cost_modifier")
+    def get_cost(self):
+        cost = 0
+        cost += self.tonnage
+        for wep in self.weapons:
+            cost += wep.cost
 
     def add_weapon(self, part):
         """

--- a/imperium/resources/hull_turrets.json
+++ b/imperium/resources/hull_turrets.json
@@ -41,6 +41,7 @@
     },
     "weapons": {
         "Pulse Laser": {
+            "name": "Pulse Laser",
             "tl": 7,
             "opt_range": "Short",
             "damage": "1d6",
@@ -50,6 +51,7 @@
             ]
         },
         "Beam Laser": {
+            "name": "Beam Laser",
             "tl": 7,
             "opt_range": "Medium",
             "damage": "2d6",
@@ -59,6 +61,7 @@
             ]
         },
         "Particle Beam": {
+            "name": "Particle Beam",
             "tl": 8,
             "opt_range": "Long",
             "damage": "3d6 + crew_hit",
@@ -69,6 +72,7 @@
             ]
         },
         "Missile Rack": {
+            "name": "Missile Rack",
             "tl": 6,
             "opt_range": "Special",
             "damage": "Missile Dependent",
@@ -80,6 +84,7 @@
             ]
         },
         "Sandcaster": {
+            "name": "Sandcaster",
             "tl": 7,
             "opt_range": "Special",
             "damage": "Special",

--- a/imperium/resources/hull_turrets.json
+++ b/imperium/resources/hull_turrets.json
@@ -81,7 +81,12 @@
               "Launcher for small anti-ship missiles",
               "Damage depends on the type of missile used",
               "Require ammunition - 12 missiles take up one ton of space"
-            ]
+            ],
+            "types": {
+                "Basic": 0.015,
+                "Smart": 0.03,
+                "Nuclear": 0.045
+            }
         },
         "Sandcaster": {
             "name": "Sandcaster",
@@ -93,7 +98,8 @@
               "Defensive weapon that dispense small particles which counteract the strength of lasers",
               "Reduces the damage from a beam weapon by 1d6",
               "Requires ammunition - 12 barrels take up one ton of space, cost .01 MCr."
-            ]
+            ],
+            "barrel_cost": 0.01
         }
     }
 }

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -784,6 +784,7 @@ class Window(QWidget):
         self.num_active += 1
         self.spacecraft.add_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
+        self.update_stats()
 
     def remove_hardpoint(self, button, hardpoint, active):
         """
@@ -874,15 +875,19 @@ class Window(QWidget):
         :param hardpoint: hardpoint object with turret
         """
         # Clearing out old weapons
-        for i in reversed(range(3, layout.count())):
+        for i in reversed(range(7, layout.count())):
             layout.itemAt(i).widget().setParent(None)
+
+        # If turret is None, don't display weps
+        if hardpoint.turret is None:
+            return
 
         # Creating objects to display weapons
         row = 4
         for idx in range(hardpoint.turret.max_wep):
             label, combobox = self.add_turret_weapon(idx, hardpoint)
             layout.addWidget(label, row + idx, 0)
-            layout.addWidget(combobox, row + idx, 1)
+            layout.addWidget(combobox, row + idx, 1, 1, -1)
 
     def add_turret_weapon(self, idx, hardpoint):
         """

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -741,11 +741,30 @@ class Window(QWidget):
         """
         row = len(self.spacecraft.hardpoints) + 2
 
+        # Defining HP and remove button
+        button = QPushButton("-")
         test = QLabel("HP")
-        self.hp_config_layout.addWidget(test, row, 0)
-        self.spacecraft.hardpoints.append("TEST")
+
+        # Functionality of the button
+        button.clicked.connect(lambda: self.remove_hardpoint(button, test))
+        button.clicked.connect(button.deleteLater)
+        button.clicked.connect(test.deleteLater)
+
+        self.hp_config_layout.addWidget(button, row, 0)
+        self.hp_config_layout.addWidget(test, row, 1)
+        self.spacecraft.add_hardpoint(test)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
-        self.update_stats()
+
+    def remove_hardpoint(self, button, test):
+        """
+        Handles the functionality of removing a single hardpoint from the ship and GUI
+        :param button:
+        :param test:
+        """
+        self.hp_config_layout.removeWidget(button)
+        self.hp_config_layout.removeWidget(test)
+        self.spacecraft.remove_hardpoint(test)
+        self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
 
 
 if __name__ == '__main__':

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -306,7 +306,7 @@ class Window(QWidget):
         self.hp_config_layout.addWidget(self.total_hp, 0, 1)
 
         self.hp_config_layout.addWidget(QLabel("Avail: "), 0, 2)
-        self.avail_hp = QLabel(str(self.spacecraft.num_hardpoints - len(self.spacecraft.turrets)))
+        self.avail_hp = QLabel(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
         self.hp_config_layout.addWidget(self.avail_hp, 0, 3)
 
         # Add button connecting to adding a hardpoint

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -294,6 +294,21 @@ class Window(QWidget):
         self.hp_config_layout = QGridLayout()
         self.hp_config_layout.setAlignment(Qt.AlignTop)
 
+        # Total and available hardpoints
+        self.hp_config_layout.addWidget(QLabel("Total: "), 0, 0)
+        self.total_hp = QLabel(str(self.spacecraft.num_hardpoints))
+        self.hp_config_layout.addWidget(self.total_hp, 0, 1)
+
+        self.hp_config_layout.addWidget(QLabel("Avail: "), 0, 2)
+        self.avail_hp = QLabel(str(self.spacecraft.num_hardpoints - len(self.spacecraft.turrets)))
+        self.hp_config_layout.addWidget(self.avail_hp, 0, 3)
+
+        # Add button connecting to adding a hardpoint
+        add_hp = QPushButton("Add")
+        add_hp.clicked.connect(self.add_hardpoint)
+        self.hp_config_layout.addWidget(add_hp, 0, 4)
+
+
         self.hp_config_group.setLayout(self.hp_config_layout)
         ###################################
         ###  END: Hardpoint Grid        ###
@@ -312,7 +327,6 @@ class Window(QWidget):
         self.computer_config_group.setFixedHeight(FIXED_HEIGHT)
         self.misc_config_group.setFixedHeight(FIXED_HEIGHT)
         self.hp_config_group.setFixedHeight(FIXED_HEIGHT)
-        # self.setFixedHeight(FIXED_HEIGHT)
 
         # Overall layout grid
         layout = QGridLayout()
@@ -383,6 +397,12 @@ class Window(QWidget):
             if self.spacecraft.pplant is not None and self.spacecraft.pplant.type != lowest_drive:
                 self.pplant_line_edit.setText(lowest_drive)
                 self.edit_pplant()
+
+        # Update hardpoint counter
+        self.total_hp.setText(str(self.spacecraft.num_hardpoints))
+        self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
+
+        # Update stats
         self.update_stats()
 
     def edit_fuel(self):
@@ -713,6 +733,18 @@ class Window(QWidget):
     def modify_fuel_scoops(self):
         # Flips the fuel scoop box
         self.spacecraft.modify_fuel_scoops()
+        self.update_stats()
+
+    def add_hardpoint(self):
+        """
+        Handles adding a hardpoint to the ship with an arrow to modify turret options
+        """
+        row = len(self.spacecraft.hardpoints) + 2
+
+        test = QLabel("HP")
+        self.hp_config_layout.addWidget(test, row, 0)
+        self.spacecraft.hardpoints.append("TEST")
+        self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
         self.update_stats()
 
 

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -287,6 +287,18 @@ class Window(QWidget):
         ###  END: Misc Items Grid       ###
         ###################################
 
+        ###################################
+        ###  START: Hardpoint Grid      ###
+        ###################################
+        self.hp_config_group = QGroupBox("Hardpoints:")
+        self.hp_config_layout = QGridLayout()
+        self.hp_config_layout.setAlignment(Qt.AlignTop)
+
+        self.hp_config_group.setLayout(self.hp_config_layout)
+        ###################################
+        ###  END: Hardpoint Grid        ###
+        ###################################
+
         # Setting appropriate column widths
         base_stats_group.setFixedWidth(175)
         self.armor_config_group.setFixedWidth(250)
@@ -294,12 +306,13 @@ class Window(QWidget):
         self.misc_config_group.setFixedWidth(250)
 
         # Setting appropriate layout heights
-        FIXED_HEIGHT = 400
+        FIXED_HEIGHT = 350
         base_stats_group.setFixedHeight(FIXED_HEIGHT)
         self.armor_config_group.setFixedHeight(FIXED_HEIGHT)
         self.computer_config_group.setFixedHeight(FIXED_HEIGHT)
         self.misc_config_group.setFixedHeight(FIXED_HEIGHT)
-        self.setFixedHeight(FIXED_HEIGHT)
+        self.hp_config_group.setFixedHeight(FIXED_HEIGHT)
+        # self.setFixedHeight(FIXED_HEIGHT)
 
         # Overall layout grid
         layout = QGridLayout()
@@ -307,7 +320,8 @@ class Window(QWidget):
         layout.addWidget(self.armor_config_group, 0, 1)
         layout.addWidget(self.computer_config_group, 0, 2)
         layout.addWidget(self.misc_config_group, 0, 3)
-        layout.addWidget(self.logger, 1, 0, 1, -1)
+        layout.addWidget(self.hp_config_group, 1, 0)
+        # layout.addWidget(self.logger, 1, 0, 1, -1)
         self.setLayout(layout)
 
         # Update to current stats

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -896,15 +896,19 @@ class Window(QWidget):
         # Missile ammo
         row = 9
         for key in hardpoint.turret.missiles.keys():
-            label, edit = self.add_turret_ammo(hardpoint, key)
+            label = QLabel("{} Missiles:".format(key))
+            total_label, edit = self.add_turret_ammo(hardpoint, key)
             layout.addWidget(label, row, 0)
-            layout.addWidget(edit, row, 1)
+            layout.addWidget(total_label, row, 1)
+            layout.addWidget(edit, row, 2)
             row += 1
 
         # Sandcaster barrels
-        label, edit = self.add_turret_ammo(hardpoint, "Sandcaster")
+        label = QLabel("Sandcaster Barrels:")
+        total_label, edit = self.add_turret_ammo(hardpoint, "Sandcaster")
         layout.addWidget(label, row, 0)
-        layout.addWidget(edit, row, 1)
+        layout.addWidget(total_label, row, 1)
+        layout.addWidget(edit, row, 2)
 
     def add_turret_weapon(self, idx, hardpoint):
         """
@@ -936,19 +940,20 @@ class Window(QWidget):
         :param key: key object
         :return: QLabel and QLineEdit with connected function
         """
-        label = QLabel("{} Missiles (12/#):".format(key))
         edit = QLineEdit()
         edit.setValidator(QIntValidator(edit))
         edit.validator().setBottom(0)
         edit.setMaximumWidth(20)
 
         if key != "Sandcaster":
+            total_label = QLabel(str(hardpoint.turret.missiles.get(key) * 12))
             edit.setText(str(hardpoint.turret.missiles.get(key)))
-            edit.editingFinished.connect(lambda: self.modify_turret_ammo(hardpoint.turret, key, edit))
+            edit.editingFinished.connect(lambda: self.modify_turret_ammo(hardpoint.turret, key, total_label, edit))
         else:
+            total_label = QLabel(str(hardpoint.turret.sandcaster_barrels * 20))
             edit.setText(str(hardpoint.turret.sandcaster_barrels))
-            edit.editingFinished.connect(lambda: self.modify_turret_sandcaster(hardpoint.turret, edit))
-        return label, edit
+            edit.editingFinished.connect(lambda: self.modify_turret_sandcaster(hardpoint.turret, total_label, edit))
+        return total_label, edit
 
     def modify_turret_model(self, layout, hardpoint, box):
         """
@@ -977,17 +982,20 @@ class Window(QWidget):
         turret.modify_weapon(wep, idx)
         self.update_stats()
 
-    def modify_turret_ammo(self, turret, type, edit):
+    def modify_turret_ammo(self, turret, type, total_label, edit):
         # Handles modifying a turret's ammo
         num = int(edit.text())
         turret.modify_missile_ammo(type, num)
+        total_label.setText(str(num * 12))
         self.update_stats()
 
-    def modify_turret_sandcaster(self, turret, edit):
+    def modify_turret_sandcaster(self, turret, total_label, edit):
         # Handles modifying a turret's sandcaster
         num = int(edit.text())
         turret.modify_sandcaster_barrel(num)
+        total_label.setText(str(num * 20))
         self.update_stats()
+
 
 if __name__ == '__main__':
     import sys

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -798,6 +798,7 @@ class Window(QWidget):
         print(self.num_active)
         self.spacecraft.remove_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
+        self.update_stats()
 
     def display_turret(self, layout, active, hardpoint):
         """
@@ -815,10 +816,11 @@ class Window(QWidget):
         for i in reversed(range(layout.count())):
             layout.itemAt(i).widget().setParent(None)
 
-        # Displaying hardpoint information
+        """ Displaying hardpoint/turret information """
         label = QLabel(str(hardpoint.id))
         layout.addWidget(label, 0, 0)
 
+        # Combobox for turret model on hardpoint
         turret_box = QComboBox()
         turret_box.addItem("---")
         idx = 1
@@ -827,6 +829,23 @@ class Window(QWidget):
             if hardpoint.turret is not None and hardpoint.turret.name == key:
                 turret_box.setCurrentIndex(idx)
             idx += 1
+
+        # Checkboxes for pop-up and fixed mounting
+        popup_label = QLabel("Pop-up Cover:")
+        popup_check = QCheckBox()
+        if hardpoint.popup is True:
+            popup_check.setChecked(True)
+        popup_check.clicked.connect(lambda: self.modify_turret_option(hardpoint, "Pop-up Turret"))
+        layout.addWidget(popup_label, 2, 0)
+        layout.addWidget(popup_check, 2, 1)
+
+        fixed_label = QLabel("Fixed Mounting:")
+        fixed_check = QCheckBox()
+        if hardpoint.fixed is True:
+            fixed_check.setChecked(True)
+        fixed_check.clicked.connect(lambda: self.modify_turret_option(hardpoint, "Fixed Mounting"))
+        layout.addWidget(fixed_label, 3, 0)
+        layout.addWidget(fixed_check, 3, 1)
 
         turret_box.currentTextChanged.connect(lambda: self.modify_turret_model(hardpoint, turret_box))
         layout.addWidget(turret_box, 1, 0)
@@ -838,8 +857,17 @@ class Window(QWidget):
         :param box: PyQT ComboBox
         """
         model = box.currentText()
-        turret = Turret(model)
+        if model == "---":
+            turret = None
+        else:
+            turret = Turret(model)
         hardpoint.add_turret(turret)
+        self.update_stats()
+
+    def modify_turret_option(self, hardpoint, part):
+        # Handles modifying a hardpoint's addon
+        hardpoint.modify_addon(part)
+        self.update_stats()
 
 
 if __name__ == '__main__':

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -792,6 +792,12 @@ class Window(QWidget):
         :param hardpoint: hardpoint class
         :param active: button to display information
         """
+        # Wipe out turret layout if removed turret is displayed
+        if active.isEnabled() == False:
+            for i in reversed(range(self.turret_config_layout.count())):
+                self.turret_config_layout.itemAt(i).widget().setParent(None)
+
+        # Removing GUI elements
         self.hp_config_layout.removeWidget(button)
         self.hp_config_layout.removeWidget(active)
 

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -6,6 +6,7 @@ Entrypoint for the imperium-shipyard program (https://github.com/Milkshak3s/impe
 from imperium.models.computer import Computer
 from imperium.models.config import Config
 from imperium.models.drives import MDrive, JDrive
+from imperium.models.hardpoint import Hardpoint
 from imperium.models.json_reader import get_file_data
 from imperium.models.misc import Misc
 from imperium.models.option import Option
@@ -305,13 +306,25 @@ class Window(QWidget):
 
         # Add button connecting to adding a hardpoint
         add_hp = QPushButton("Add")
+        add_hp.setMaximumWidth(30)
         add_hp.clicked.connect(self.add_hardpoint)
         self.hp_config_layout.addWidget(add_hp, 0, 4)
-
 
         self.hp_config_group.setLayout(self.hp_config_layout)
         ###################################
         ###  END: Hardpoint Grid        ###
+        ###################################
+
+        ###################################
+        ###  START: Turret Grid         ###
+        ###################################
+        self.turret_config_group = QGroupBox("Active Turret:")
+        self.turret_config_layout = QGridLayout()
+        self.turret_config_layout.setAlignment(Qt.AlignTop)
+
+        self.turret_config_group.setLayout(self.turret_config_layout)
+        ###################################
+        ###  END: Turret Grid           ###
         ###################################
 
         # Setting appropriate column widths
@@ -335,6 +348,7 @@ class Window(QWidget):
         layout.addWidget(self.computer_config_group, 0, 2)
         layout.addWidget(self.misc_config_group, 0, 3)
         layout.addWidget(self.hp_config_group, 1, 0)
+        layout.addWidget(self.turret_config_group, 1, 1)
         # layout.addWidget(self.logger, 1, 0, 1, -1)
         self.setLayout(layout)
 
@@ -742,28 +756,37 @@ class Window(QWidget):
         row = len(self.spacecraft.hardpoints) + 2
 
         # Defining HP and remove button
-        button = QPushButton("-")
-        test = QLabel("HP")
+        remove = QPushButton("HP")
+        hardpoint = Hardpoint()
+        active = QPushButton(">")
+        active.setMaximumWidth(30)
 
         # Functionality of the button
-        button.clicked.connect(lambda: self.remove_hardpoint(button, test))
-        button.clicked.connect(button.deleteLater)
-        button.clicked.connect(test.deleteLater)
+        remove.clicked.connect(lambda: self.remove_hardpoint(remove, hardpoint, active))
+        remove.clicked.connect(remove.deleteLater)
+        remove.clicked.connect(active.deleteLater)
 
-        self.hp_config_layout.addWidget(button, row, 0)
-        self.hp_config_layout.addWidget(test, row, 1)
-        self.spacecraft.add_hardpoint(test)
+        # Adding to GUI
+        self.hp_config_layout.addWidget(remove, row, 0, 1, 4)
+        self.hp_config_layout.addWidget(active, row, 4)
+
+        # Adding hp to ship, updating available hps
+        self.spacecraft.add_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
 
-    def remove_hardpoint(self, button, test):
+    def remove_hardpoint(self, button, hardpoint, active):
         """
         Handles the functionality of removing a single hardpoint from the ship and GUI
         :param button:
-        :param test:
+        :param hardpoint:
+        :param label:
+        :param active:
         """
         self.hp_config_layout.removeWidget(button)
-        self.hp_config_layout.removeWidget(test)
-        self.spacecraft.remove_hardpoint(test)
+        self.hp_config_layout.removeWidget(active)
+
+        # Adding hp to ship, updating available hps
+        self.spacecraft.remove_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
 
 

--- a/imperium/shipyard.py
+++ b/imperium/shipyard.py
@@ -310,6 +310,9 @@ class Window(QWidget):
         add_hp.clicked.connect(self.add_hardpoint)
         self.hp_config_layout.addWidget(add_hp, 0, 4)
 
+        # Global list to hold active button objects
+        self.active_hp_buttons = list()
+
         self.hp_config_group.setLayout(self.hp_config_layout)
         ###################################
         ###  END: Hardpoint Grid        ###
@@ -753,41 +756,64 @@ class Window(QWidget):
         """
         Handles adding a hardpoint to the ship with an arrow to modify turret options
         """
-        row = len(self.spacecraft.hardpoints) + 2
+        row = len(self.spacecraft.hardpoints) + 1
+        print(row)
 
         # Defining HP and remove button
-        remove = QPushButton("HP")
-        hardpoint = Hardpoint()
+        remove = QPushButton("HP {}".format(row))
+        hardpoint = Hardpoint(row)
         active = QPushButton(">")
         active.setMaximumWidth(30)
 
-        # Functionality of the button
+        # Button functionalities
         remove.clicked.connect(lambda: self.remove_hardpoint(remove, hardpoint, active))
         remove.clicked.connect(remove.deleteLater)
         remove.clicked.connect(active.deleteLater)
+        active.clicked.connect(lambda: self.display_turret(self.turret_config_layout, active, hardpoint))
 
         # Adding to GUI
         self.hp_config_layout.addWidget(remove, row, 0, 1, 4)
         self.hp_config_layout.addWidget(active, row, 4)
 
         # Adding hp to ship, updating available hps
+        self.active_hp_buttons.append(active)
         self.spacecraft.add_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
 
     def remove_hardpoint(self, button, hardpoint, active):
         """
         Handles the functionality of removing a single hardpoint from the ship and GUI
-        :param button:
-        :param hardpoint:
-        :param label:
-        :param active:
+        :param button: hardpoint button to remove
+        :param hardpoint: hardpoint class
+        :param active: button to display information
         """
         self.hp_config_layout.removeWidget(button)
         self.hp_config_layout.removeWidget(active)
 
         # Adding hp to ship, updating available hps
+        self.active_hp_buttons.remove(active)
         self.spacecraft.remove_hardpoint(hardpoint)
         self.avail_hp.setText(str(self.spacecraft.num_hardpoints - len(self.spacecraft.hardpoints)))
+
+    def display_turret(self, layout, active, hardpoint):
+        """
+        Handles displaying a hardpoint's information and updating the active buttons
+        :param active: active button to set disabled
+        :param hardpoint: hardpoint holding a turret to display
+        """
+        for button in self.active_hp_buttons:
+            if button is active:
+                button.setDisabled(True)
+            else:
+                button.setEnabled(True)
+
+        # Clear the previous layout
+        for i in reversed(range(layout.count())):
+            layout.itemAt(i).widget().setParent(None)
+
+        # Displaying hardpoint information
+        label = QLabel(str(hardpoint.id))
+        layout.addWidget(label, 0, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_bayweapons.py
+++ b/tests/test_bayweapons.py
@@ -29,8 +29,8 @@ def test_add_remove():
     assert ship.get_remaining_cargo() == 100
     
     ship.add_bayweapon(wep)
-    assert ship.get_total_cost() == 14
-    assert ship.get_remaining_cargo() == 49
+    assert ship.get_total_cost() == 2
+    assert ship.get_remaining_cargo() == 100
 
     ship.remove_bayweapon(wep)
     assert ship.get_total_cost() == 2

--- a/tests/test_spacecraft.py
+++ b/tests/test_spacecraft.py
@@ -6,6 +6,7 @@ Unit tests for classes in shipyard.models.spacecraft
 import pytest
 
 from imperium.models.config import Config
+from imperium.models.hardpoint import Hardpoint
 from imperium.models.spacecraft import Spacecraft
 from imperium.models.turrets import Turret
 from imperium.models.armour import Armour
@@ -33,20 +34,19 @@ def test_turret_functionality():
     ship = Spacecraft(100)
 
     # Turret init with a wep and addon
+    hardpoint = Hardpoint("1")
     turret = Turret("Single Turret")
-    turret.add_weapon("Beam Laser")
-    turret.add_addon("Pop-up Turret")
+    hardpoint.add_turret(turret)
+    turret.modify_weapon("Beam Laser", 0)
 
     # Adding and removing the turret, checking ship specs
-    ship.add_turret(turret)
-    assert ship.get_remaining_cargo() == 97
-    assert ship.get_total_cost() == 4.2
-    assert len(ship.turrets) == 1
+    ship.add_hardpoint(hardpoint)
+    assert ship.get_remaining_cargo() == 98
+    assert ship.get_total_cost() == 3.2
 
-    ship.remove_turret(0)
-    assert ship.get_remaining_cargo() == 100
-    assert ship.get_total_cost() == 2.0
-    assert len(ship.turrets) == 0
+    turret.modify_weapon("---", 0)
+    assert ship.get_remaining_cargo() == 98
+    assert ship.get_total_cost() == 2.2
 
 
 def test_set_tonnage():

--- a/tests/test_turrets.py
+++ b/tests/test_turrets.py
@@ -14,22 +14,21 @@ def test_single_turret():
     print("--- Test for Single Turret ---")
     turret = Turret("Single Turret")
     assert turret.tonnage == 1.0
-    assert turret.cost == 0.2
+    assert turret.get_cost() == 0.2
     assert turret.max_wep == 1
 
-    turret.add_weapon("Pulse Laser")
+    turret.modify_weapon("Pulse Laser", 0)
     assert turret.tonnage == 1.0
-    assert turret.cost == 0.7
-    assert len(turret.weapons) == 1
+    assert turret.get_cost() == 0.7
 
-    turret.remove_weapon("Pulse Laser")
+    turret.modify_weapon("---", 0)
 
-    turret.add_weapon("Beam Laser")
+    turret.modify_weapon("Beam Laser", 0)
     assert turret.tonnage == 1.0
-    assert turret.cost == 1.2
+    assert turret.get_cost() == 1.2
     assert turret.max_wep == 1
 
-    turret.add_weapon("Particle Beam")
+    turret.modify_weapon("---", 0)
     print("--- Passed test for Single Turret! ---")
 
 
@@ -43,30 +42,22 @@ def test_double_turret():
     # Init of a double turret
     turret = Turret("Double Turret")
     assert turret.tonnage == 1.0
-    assert turret.cost == 0.5
+    assert turret.get_cost() == 0.5
     assert turret.max_wep == 2
 
     # Adding and removing weapons
-    turret.add_weapon("Pulse Laser")
+    turret.modify_weapon("Pulse Laser", 0)
     assert turret.tonnage == 1.0
-    assert turret.cost == 1.0
-    assert len(turret.weapons) == 1
+    assert turret.get_cost() == 1.0
 
-    turret.add_weapon("Beam Laser")
+    turret.modify_weapon("Beam Laser", 1)
     assert turret.tonnage == 1.0
-    assert turret.cost == 2.0
-    assert len(turret.weapons) == 2
+    assert turret.get_cost() == 2.0
 
-    turret.remove_weapon("Pulse Laser")
+    turret.modify_weapon("---", 0)
     assert turret.tonnage == 1.0
-    assert turret.cost == 1.5
-    assert len(turret.weapons) == 1
+    assert turret.get_cost() == 1.5
 
-    # Testing pop-up turret add-on functionality
-    turret.add_addon("Pop-up Turret")
-    assert turret.tonnage == 3.0
-    assert turret.cost == 2.5
-    assert len(turret.weapons) == 1
     print("--- Passed test for Double Turret! ---")
 
 
@@ -76,27 +67,20 @@ def test_triple_turret():
     # Init of a triple turret
     turret = Turret("Triple Turret")
     assert turret.tonnage == 1.0
-    assert turret.cost == 1.0
+    assert turret.get_cost() == 1.0
     assert turret.max_wep == 3
 
     # Adding three weapons
-    turret.add_weapon("Pulse Laser")
+    turret.modify_weapon("Pulse Laser", 0)
     assert turret.tonnage == 1.0
-    assert turret.cost == 1.5
-    assert len(turret.weapons) == 1
+    assert turret.get_cost() == 1.5
 
-    turret.add_weapon("Beam Laser")
+    turret.modify_weapon("Beam Laser", 1)
     assert turret.tonnage == 1.0
-    assert turret.cost == 2.5
-    assert len(turret.weapons) == 2
+    assert turret.get_cost() == 2.5
 
-    turret.add_weapon("Pulse Laser")
+    turret.modify_weapon("Pulse Laser", 2)
     assert turret.tonnage == 1.0
-    assert turret.cost == 3.0
-    assert len(turret.weapons) == 3
+    assert turret.get_cost() == 3.0
 
-    # Testing add-on cost manipulation
-    turret.add_addon("Fixed Mounting")
-    assert turret.tonnage == 1.0
-    assert turret.cost == 1.5
     print("--- Passed test for Triple Turret! ---")


### PR DESCRIPTION
Big PR implementing hardpoint and turret functionality to the calculator

Features:
- 2 new layouts, one for hardpoints and turrets
- Stats to show total and available hardpoints
- Adding a hardpoint makes two buttons, one for removal and one for display
- Displaying a hardpoint shows info on the turret and addons, as well as allowing the ability to add and modify weapons
- All costs and tonnages are updated in real time

Limitations:
- No bayweapons yet
- Bug where removing a middle button and adding causes overlapping on last line (happens with armor as well)
- Hardpoint layout gets squished after 10 hardpoints, needs overflow layout/2 columns